### PR TITLE
v0.5: Fixes the "stream_type" missing key when searching series. Fixes #4

### DIFF
--- a/xtreamPOC.json
+++ b/xtreamPOC.json
@@ -3,23 +3,23 @@
     "config_version": 0.5,
     "mpv_path": "C:\\path\\to\\mpv\\mpv.exe",
     "time_out": 4,
-    "default": "1",
+    "default": "2",
     "shift_1-9": "!\"#$%&/()",
     "iptv_providers": [
         {
-            "provider_name": "YourProviderName1",
+            "provider_name": "YourProviderName01",
             "username": "user",
             "password": "1234",
             "provider_url": "http://yourproviderurl.com:8080/"
         },
         {
-            "provider_name": "YourProviderName2",
+            "provider_name": "YourProviderName02",
             "username": "user",
             "password": "5678",
             "provider_url": "http://yourproviderurl.xyz:8080/"
         },
         {
-            "provider_name": "YourProviderName3",
+            "provider_name": "YourProviderName03",
             "username": "user",
             "password": "9876",
             "provider_url": "http://yourproviderurl.vip:8080/"

--- a/xtreamPOC.py
+++ b/xtreamPOC.py
@@ -10,6 +10,7 @@ Version History:
 - v0.2 (2024-09-15): Adds "Replay" switch to replay stream when it fails.
 - v0.3 (2024-09-30): Supports multiple IPTV providers with default selection.
 - v0.4 (2024-10-01): Fixes the 403 error when trying to get series info.
+- v0.5 (2024-10-04): Fixes the "stream_type" missing key when searching series.
 
 Copyright 2024 Mario Montoya
 
@@ -109,7 +110,8 @@ async def ui_search_stream():
     # Iterates the streams
     print("Type - Stream Id - Name", end="")
     for stream in streams:
-        if stream['stream_type'] == 'series':
+        stream_type = stream.get('stream_type', 'series')
+        if stream_type == 'series':
             series_id = stream['series_id']
             info_url = xt.get_series_info_URL_by_ID(series_id)
             # Add series_id without repetition
@@ -117,8 +119,8 @@ async def ui_search_stream():
                 info_urls.append(info_url)
         else:
             print('')
-            print(f"{stream['stream_type']} - {stream['stream_id']} - {stream['name']}", end="")
-            add_card(stream['stream_type'], stream['stream_id'], stream['name'], stream['stream_icon'], streams=streams)
+            print(f"{stream_type} - {stream['stream_id']} - {stream['name']}", end="")
+            add_card(stream_type, stream['stream_id'], stream['name'], stream['stream_icon'], streams=streams)
             ui.update() # Required in slower PCs.
             await asyncio.sleep(.25) # Required for ui self-refresh.
     print('')


### PR DESCRIPTION
This update addresses the missing "stream_type" key when searching for series. The key is now checked with a default value of "series" to ensure proper functionality even when the key is not present. A variable ```stream_type``` has been introduced to replace direct access to ```stream['stream_type']```.

These changes improve code reliability and prevent potential errors related to missing keys.