### PR TITLE
Add Stream Recording Functionality and Restrict Replay Action to Live Channels Related Issue: #5

### DIFF
--- a/xtreamPOC.json
+++ b/xtreamPOC.json
@@ -1,25 +1,27 @@
 {
     "product": "Proof Of Concept Xtream Codes",
-    "config_version": 0.5,
+    "config_version": 0.6,
     "mpv_path": "C:\\path\\to\\mpv\\mpv.exe",
+    "mpv_rec_win": "C:\\path\\to\\recordings\\",
+    "mpv_rec_linux": "~/Desktop/recordings/",
     "time_out": 4,
-    "default": "2",
+    "default": "1",
     "shift_1-9": "!\"#$%&/()",
     "iptv_providers": [
         {
-            "provider_name": "YourProviderName01",
+            "provider_name": "YourProviderName1",
             "username": "user",
             "password": "1234",
             "provider_url": "http://yourproviderurl.com:8080/"
         },
         {
-            "provider_name": "YourProviderName02",
+            "provider_name": "YourProviderName2",
             "username": "user",
             "password": "5678",
             "provider_url": "http://yourproviderurl.xyz:8080/"
         },
         {
-            "provider_name": "YourProviderName03",
+            "provider_name": "YourProviderName3",
             "username": "user",
             "password": "9876",
             "provider_url": "http://yourproviderurl.vip:8080/"


### PR DESCRIPTION
**Related Issue: [#5](https://github.com/sght500/xtreamPOC/issues/5)**

### Description:
This pull request addresses the core requirement outlined in issue [#5](https://github.com/sght500/xtreamPOC/issues/5), which is to enable the ability to record a live stream in the xtreamPOC project. The implemented functionality adds a **"Record"** checkbox in the user interface, allowing users to record live streams to a predetermined folder. While playback functionality isn't part of this MVP, users will still have manual access to the folder for file playback.

In addition to the core recording feature, I've expanded the functionality to improve the **"Replay"** feature by restricting it to **live channels only**. This prevents movies or other non-live content from restarting when "Replay" is selected, which would lead to an undesirable user experience where the content begins from the start unnecessarily. Now, only live streams can be replayed from the beginning, which makes sense for event-based content where users might join late and want to watch from the start.

### **Key Features:**
- **Recording a Stream:**
  - A checkbox labeled **"Record"** in the user interface to toggle recording.
  - The stream is saved to a predetermined folder for easy access.
  - Recording playback is **excluded** from the MVP for now.
  
- **Replay Functionality Improvement:**
  - **Replay** is now restricted to **live channels** only, ensuring movies or on-demand content are not restarted unnecessarily.

### **Additional Considerations:**
This PR lays the foundation for future expansions, such as:
- Customizable file naming.
- User-selected folder destinations.
- Enhanced playback control and management.

By merging this PR, we streamline the recording and replay functionality, making live stream interactions smoother and more intuitive for users, especially for time-sensitive or event-based content.
